### PR TITLE
Provides objectid field type and prepares for modular field definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ $ mongoose-gen -m car -f carDoor:number,color -r
   - date
   - boolean
   - array
+  - objectid
+
+Note about the ObjectId type:
+the `objectid` type stores a `_id`.
+When created, it will prompt for a `ref` value.
+The `ref` is the name of the model that contains the doc with the provided `_id` value. (See example bellow)
 
 ### Interactive mode
 
@@ -42,6 +48,9 @@ Field Name (press <return> to stop adding fields) : door
 Field Type [string] : number
 Field Name (press <return> to stop adding fields) : color
 Field Type [string] : 
+Field Name (press <return> to stop adding fields) : owner
+Field Type [string] : objectid
+Ref (model name refered by the objectid field): user
 Field Name (press <return> to stop adding fields) : 
 Generate Rest (yes/no) ? [yes] : 
         create: ./models/cardModel.js
@@ -59,6 +68,10 @@ var Schema   = mongoose.Schema;
 var carSchema = new Schema({
 	"color" : String,
 	"door" : Number
+    "owner": {
+        type: mongoose.Schema.Types.ObjectId,
+        ref : 'user'
+    }
 });
 
 module.exports = mongoose.model('car', carSchema);

--- a/bin/mongoose-gen
+++ b/bin/mongoose-gen
@@ -52,7 +52,8 @@ function runInteractiveMode(path){
             fields: function (cb){
                 var exit   = false;
                 var fields = [];
-
+                var currentField = {};
+                
                 async.whilst(
                     function(){ return !exit; },
                     function(cb){

--- a/bin/mongoose-gen
+++ b/bin/mongoose-gen
@@ -17,7 +17,7 @@ var rl = readline.createInterface({
     output: process.stdout
 });
 
-var allowedFieldsTypes = ['string', 'number', 'date', 'boolean', 'array'];
+var allowedFieldsTypes = ['string', 'number', 'date', 'boolean', 'array', 'objectid'];
 
 // CLI
 program
@@ -45,7 +45,7 @@ function runInteractiveMode(path){
     async.series({
             name: function (cb){
                 askQuestion('Model Name : ', isModelNameParamValid, function (name){
-                    console.log(cliStyles.green + 'Available types : string, number, date, boolean, array' + cliStyles.reset);
+                    console.log(cliStyles.green + 'Available types '+ allowedFieldsTypes.toString() + cliStyles.reset);
                     cb(null, name);
                 });
             },
@@ -70,6 +70,16 @@ function runInteractiveMode(path){
                                         fieldType = (fieldType.trim().length === 0) ? 'string' : fieldType;
                                         cb(null, fieldType);
                                     });
+                                },
+                                ref: function(cb){
+                                    if(currentField.type === 'objectid') {
+                                            askQuestion('Ref (model name refered by the objectid field): ', null, function(ref){
+                                                ref = (ref.trim().length === 0) ? 'INSERT_YOUR_REF_HERE' : ref;
+                                                cb(null, ref);
+                                            });
+                                        } else {
+                                            cb(null, null);
+                                        }
                                 }
                             },
                             function (err, results){

--- a/bin/mongoose-gen
+++ b/bin/mongoose-gen
@@ -69,6 +69,7 @@ function runInteractiveMode(path){
                                 type: function(cb){
                                     askQuestion('Field Type [string] : ', isFieldTypeParamValid, function(fieldType){
                                         fieldType = (fieldType.trim().length === 0) ? 'string' : fieldType;
+                                        currentField.type = fieldType;
                                         cb(null, fieldType);
                                     });
                                 },

--- a/lib/fieldTypes.js
+++ b/lib/fieldTypes.js
@@ -1,0 +1,10 @@
+var objectID = {
+    name: "{\r"+
+    "\t \t type: mongoose.Schema.ObjectId, \r"+
+    "\t \t ref: '{ref}' \r"+
+    "\t }"
+};
+
+module.exports = {
+	objectID: objectID
+};

--- a/lib/formatTools.js
+++ b/lib/formatTools.js
@@ -1,10 +1,12 @@
 
+var fieldTypes = require('./fieldTypes');
 var allowedFieldsTypes = {
     "string" : String,
     "number" : Number,
     "date"   : Date,
     "boolean": Boolean,
-    "array"  : Array
+    "array"  : Array,
+    "objectID": fieldTypes.objectID
 };
 
 /**
@@ -19,6 +21,9 @@ function getFieldsForModelTemplate(fields){
     fields.forEach(function(field, index, array){
         modelFields += '\t"' + field.name + '" : ' + (allowedFieldsTypes[field.type]).name;
         modelFields += (lg > index) ? ',\r' : '\r';
+        if(field.ref){
+            modelFields = modelFields.replace(/{ref}/, field.ref );
+        }
     });
     modelFields += '}';
 

--- a/lib/formatTools.js
+++ b/lib/formatTools.js
@@ -6,7 +6,7 @@ var allowedFieldsTypes = {
     "date"   : Date,
     "boolean": Boolean,
     "array"  : Array,
-    "objectID": fieldTypes.objectID
+    "objectid": fieldTypes.objectID
 };
 
 /**


### PR DESCRIPTION
- Creates fieldTypes.js to define field types c5074ee3805d990224946f7caf93ca47eda90080 

- Adds objectid field type to array. Set console msg directly from array. Creates a variable to contain current field in edition to check if it is objectid type. If so, prompts for a ref c5074ee3805d990224946f7caf93ca47eda90080

- Adds the ref and the object id to the field template c5074ee3805d990224946f7caf93ca47eda90080

- new readme info about the objectid type c5074ee3805d990224946f7caf93ca47eda90080

I did this because this generator is great, but I really missed adding objectid field.

I acctually use a whole different folder structure in my projects, so I created this PR to share this objectid option that I already got working here
Thank you for this

(no tests written, sorry :( )