### PR TITLE
Added support for extra parameter for "array of" fields

### DIFF
--- a/bin/mongoose-gen
+++ b/bin/mongoose-gen
@@ -329,12 +329,14 @@ function formatFieldsParamInArray(fields) {
         var f = field.split(':');
         var fieldName = f[0];
         var fieldType = (f[1] || ALLOWED_FIELDS_TYPES[0]);
+        var isArray = f[2] === 'a';
 
         if (!isFieldValid(fieldName, fieldType)) { return false; }
 
         result.push({
             name: fieldName,
-            type: fieldType
+            type: fieldType,
+            array: isArray
         });
 
         return true;

--- a/lib/formatTools.js
+++ b/lib/formatTools.js
@@ -18,7 +18,7 @@ function getFieldsForModelTemplate(fields) {
 
     var modelFields = '{\r';
     fields.forEach(function(field, index, array) {
-        modelFields += '\t\'' + field.name + '\' : ' + (allowedFieldsTypes[field.type]).name;
+        modelFields += '\t\'' + field.name + '\' : '+ (field.array ? '[' : '') + (allowedFieldsTypes[field.type]).name + (field.array ? ']' : '');
         modelFields += (lg > index) ? ',\r' : '\r';
         if (field.reference) {
             modelFields = modelFields.replace(/{ref}/, field.reference);


### PR DESCRIPTION
Regarding Issue: https://github.com/DamienP33/express-mongoose-generator/issues/4

Added the option to use "fieldname:type:extra" syntax, in this case if extra is 'a' (for array) it'll produce an array of the fieldtype on the mongoose model.

Eg. "-f phone:number:a" will yield "phone: [Number]" in the model.

It works for all the types (even the Array type, might consider removing it?) and any future type (e.g. if Mongoose's Mixed type gets support).