### PR TITLE
Fix pluralName in controler.list

### DIFF
--- a/templates/controller.js
+++ b/templates/controller.js
@@ -14,7 +14,7 @@ module.exports = {
         {modelName}.find(function (err, {pluralName}) {
             if (err) {
                 return res.status(500).json({
-                    message: 'Error when getting {name}.',
+                    message: 'Error when getting {pluralName}.',
                     error: err
                 });
             }

--- a/templates/controller.ts
+++ b/templates/controller.ts
@@ -14,7 +14,7 @@ export = {
         {modelName}.find((err, {pluralName}) => {
             if (err) {
                 return res.status(500).json({
-                    message: 'Error when getting {name}.',
+                    message: 'Error when getting {pluralName}.',
                     error: err
                 });
             }


### PR DESCRIPTION
I think it is better to use the pluralName when getting the object list